### PR TITLE
nix: clean up and refactor

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,44 +1,39 @@
-{ sources ? (import ./nix/sources.nix)
-, compiler ? "ghc883"
+let
+  sources = import ./nix/sources.nix;
+in
+{ pkgs ? import sources.unstable { }
 , profiling ? false
 }:
 let
-  overlay = self: super: {
-    haskell = super.haskell // {
-      packages = super.haskell.packages // {
-        "${compiler}" = super.haskell.packages.${compiler}.override {
-          overrides = hself: hsuper: with self.haskell.lib; {
-            ede = overrideCabal hsuper.ede (
-              drv: {
-                src = sources."ede-trifecta-2.1";
-              }
-            );
-            repology-versions = import sources.repology-versions {
-              inherit sources;
-            };
+  hspkgs = pkgs.haskellPackages.override {
+    overrides = hself: hsuper: with pkgs.haskell.lib; {
+      ede = overrideCabal hsuper.ede (
+        drv: {
+          src = pkgs.fetchFromGitHub {
+            owner = "brendanhay";
+            repo = "ede";
+            rev = "5e0373b8a8c83ff2078a938795e30ec8038d228c";
+            sha256 = "1lb0q289p6lrc65adlacdx8xy8hrvcywbf6np7rilqdvvnyvlbgs";
           };
-        };
+        }
+      );
+
+      repology-versions = import sources.repology-versions {
+        inherit sources;
       };
     };
   };
 
-  pkgs = (
-    import sources.unstable {
-      overlays = [
-        overlay
-      ];
-    }
-  );
-
-  inherit (pkgs.haskellPackages)
+  inherit (hspkgs)
     callCabal2nix
-    shellFor
     ;
+
   inherit (pkgs.haskell.lib)
     enableLibraryProfiling
     enableExecutableProfiling
     justStaticExecutables
     ;
+
   inherit (pkgs)
     lib
     nix-gitignore
@@ -51,8 +46,7 @@ let
   ];
   nvs = callCabal2nix
     "nvs"
-    (nix-gitignore.gitignoreSource extra-source-excludes ./.)
-    {};
+    (nix-gitignore.gitignoreSource extra-source-excludes ./.) { };
 in
 if profiling then
   enableExecutableProfiling (enableLibraryProfiling nvs)

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,16 +1,4 @@
 {
-    "ede-trifecta-2.1": {
-        "branch": "trifecta-2.1",
-        "description": "Templating language with similar syntax and features to Liquid or Jinja2.",
-        "homepage": "",
-        "owner": "pbogdan",
-        "repo": "ede",
-        "rev": "1114be9457b15aa8f40a30e058b766048fe3479a",
-        "sha256": "1km89ahwa4r2ly85kwzp6np807lf5n81bbbszk4yhqmx0qcxcmzg",
-        "type": "tarball",
-        "url": "https://github.com/pbogdan/ede/archive/1114be9457b15aa8f40a30e058b766048fe3479a.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "repology-versions": {
         "branch": "master",
         "description": "A Haskell binding to repology's libversion.",

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,13 @@
 let
-  nvs = (import ./default.nix {});
   sources = import ./nix/sources.nix;
-  pkgs = (import sources.unstable {});
+in
+{ pkgs ? import sources.unstable { }
+
+}:
+let
+  nvs = import ./default.nix {
+    inherit pkgs;
+  };
 in
 pkgs.haskellPackages.shellFor {
   packages = _: [


### PR DESCRIPTION
- make it possible to override the input `pkgs`
- just use the default compiler, always
- pin `ede` directly from upstream, instead of niv on my fork